### PR TITLE
Make benchmark compatible with druid-0.10.0

### DIFF
--- a/benchmark-druid.R
+++ b/benchmark-druid.R
@@ -156,8 +156,8 @@ top_100_parts_details <- function(datasource) {
     aggregations = list(
       sum(metric("l_quantity")),
       sum(metric("l_extendedprice")),
-      min(metric("l_discount")),
-      max(metric("l_discount"))
+      druid.build.aggregation(type="longMin", name = "l_discount_min", fieldName = "l_discount"),
+      druid.build.aggregation(type="longMax", name = "l_discount_max", fieldName = "l_discount")
     ),
     filter = NULL,
     granularity = granularity("all"),
@@ -177,8 +177,8 @@ top_100_parts_filter <- function(datasource) {
     aggregations = list(
       sum(metric("l_quantity")),
       sum(metric("l_extendedprice")),
-      min(metric("l_discount")),
-      max(metric("l_discount"))
+      druid.build.aggregation(type="longMin", name = "l_discount_min", fieldName = "l_discount"),
+      druid.build.aggregation(type="longMax", name = "l_discount_max", fieldName = "l_discount")
     ),
     granularity = granularity("all"),
     context=list(useCache=F, populateCache=F)

--- a/lineitem.task.json
+++ b/lineitem.task.json
@@ -1,65 +1,47 @@
 {
-  "type" : "index_hadoop",
-  "hadoopCoordinates":"org.apache.hadoop:hadoop-core:0.20.205-emr",
-  "config": {
-    "dataSource" : "tpch_lineitem",
-    "timestampSpec" : {
-      "column": "l_shipdate",
-      "format": "yyyy-MM-dd"
+  "type": "index_hadoop",
+  "spec": {
+    "ioConfig": {
+      "type": "hadoop",
+      "inputSpec": {
+        "type": "static",
+        "paths": "s3:\/\/path\/to\/tpch\/data\/lineitem.tbl.*.gz"
+      }
     },
-    "dataSpec": {
-      "format": "tsv",
-      "delimiter": "|",
-      "columns": [
-        "l_orderkey",
-        "l_partkey",
-        "l_suppkey",
-        "l_linenumber",
-        "l_quantity",
-        "l_extendedprice",
-        "l_discount",
-        "l_tax",
-        "l_returnflag",
-        "l_linestatus",
-        "l_shipdate",
-        "l_commitdate",
-        "l_receiptdate",
-        "l_shipinstruct",
-        "l_shipmode",
-        "l_comment"
-      ],
-      "dimensions" : [
-        "l_orderkey",
-        "l_partkey",
-        "l_suppkey",
-        "l_linenumber",
-        "l_returnflag",
-        "l_linestatus",
-        "l_shipdate",
-        "l_commitdate",
-        "l_receiptdate",
-        "l_shipinstruct",
-        "l_shipmode",
-        "l_comment"
-      ]
-    },
-    "granularitySpec": {
-      "type": "uniform",
-      "intervals": [
-        "1980/2020"
-      ],
-      "gran": "month"
-    },
-    "partitionsSpec": {
-      "type": "random",
-      "targetPartitionSize": 5000000
-    },
-    "pathSpec": {
-      "type": "static",
-      "paths": "s3:\/\/path\/to\/tpch\/data\/lineitem.tbl.*.gz"
-    },
-    "rollupSpec": {
-      "aggs": [
+    "dataSchema": {
+      "dataSource": "tpch_lineitem_small",
+      "granularitySpec": {
+        "type": "arbitrary",
+        "internvals": ["1980/2020"],
+        "segmentGranularity" : "DAY"
+      },
+      "parser": {
+        "type": "hadoopyString",
+        "parseSpec": {
+          "format": "tsv",
+          "dimensionsSpec": {
+            "dimensions": [
+              "l_orderkey",
+              "l_partkey",
+              "l_suppkey",
+              "l_linenumber",
+              "l_returnflag",
+              "l_linestatus",
+              "l_shipdate",
+              "l_commitdate",
+              "l_receiptdate",
+              "l_shipinstruct",
+              "l_shipmode",
+              "l_comment"
+            ]
+          },
+          "timestampSpec": {
+            "column": "l_shipdate",
+            "format": "yyyy-MM-dd"
+          }
+        }
+      },
+      "metricsSpec": [
         {
           "type": "count",
           "name": "count"
@@ -84,8 +66,15 @@
           "fieldName": "L_TAX",
           "name": "L_TAX"
         }
-      ],
-      "rollupGranularity": "day"
+      ]
+    },
+    "tunningConfig": {
+      "type" : "hadoop",
+      "partitionsSpec" : {
+        "type" : "hashed",
+        "targetPartitionSize" : 5000000
+      },
+      "jobProperties" : {}
     }
   }
 }

--- a/lineitem_small.task.json
+++ b/lineitem_small.task.json
@@ -1,60 +1,47 @@
 {
-  "type" : "index_hadoop",
-  "hadoopCoordinates":"org.apache.hadoop:hadoop-core:0.20.205-emr",
-  "config": {
-    "dataSource" : "tpch_lineitem_small",
-    "timestampSpec" : {
-      "column": "l_shipdate",
-      "format": "yyyy-MM-dd"
+  "type": "index_hadoop",
+  "spec": {
+    "ioConfig": {
+      "type": "hadoop",
+      "inputSpec": {
+        "type": "static",
+        "paths": "s3:\/\/path\/to\/tpch\/data\/lineitem.tbl.*.gz"
+      }
     },
-    "dataSpec": {
-      "format": "tsv",
-      "delimiter": "|",
-      "columns": [
-        "l_orderkey",
-        "l_partkey",
-        "l_suppkey",
-        "l_linenumber",
-        "l_quantity",
-        "l_extendedprice",
-        "l_discount",
-        "l_tax",
-        "l_returnflag",
-        "l_linestatus",
-        "l_shipdate",
-        "l_commitdate",
-        "l_receiptdate",
-        "l_shipinstruct",
-        "l_shipmode",
-        "l_comment"
-      ],
-      "dimensions" : [
-        "l_orderkey",
-        "l_partkey",
-        "l_suppkey",
-        "l_linenumber",
-        "l_returnflag",
-        "l_linestatus",
-        "l_shipdate",
-        "l_commitdate",
-        "l_receiptdate",
-        "l_shipinstruct",
-        "l_shipmode",
-        "l_comment"
-      ]
-    },
-    "granularitySpec": {
-      "type": "arbitrary",
-      "intervals": [
-        "1980/2020"
-      ]
-    },
-    "pathSpec": {
-      "type": "static",
-      "paths": "s3:\/\/path\/to\/tpch\/data\/lineitem.tbl.gz"
-    },
-    "rollupSpec": {
-      "aggs": [
+    "dataSchema": {
+      "dataSource": "tpch_lineitem_small",
+      "granularitySpec": {
+        "type": "arbitrary",
+        "internvals": ["1980/2020"],
+        "segmentGranularity" : "DAY"
+      },
+      "parser": {
+        "type": "hadoopyString",
+        "parseSpec": {
+          "format": "tsv",
+          "dimensionsSpec": {
+            "dimensions": [
+              "l_orderkey",
+              "l_partkey",
+              "l_suppkey",
+              "l_linenumber",
+              "l_returnflag",
+              "l_linestatus",
+              "l_shipdate",
+              "l_commitdate",
+              "l_receiptdate",
+              "l_shipinstruct",
+              "l_shipmode",
+              "l_comment"
+            ]
+          },
+          "timestampSpec": {
+            "column": "l_shipdate",
+            "format": "yyyy-MM-dd"
+          }
+        }
+      },
+      "metricsSpec": [
         {
           "type": "count",
           "name": "count"
@@ -79,8 +66,15 @@
           "fieldName": "L_TAX",
           "name": "L_TAX"
         }
-      ],
-      "rollupGranularity": "day"
+      ]
+    },
+    "tunningConfig": {
+      "type" : "hadoop",
+      "partitionsSpec" : {
+        "type" : "hashed",
+        "targetPartitionSize" : 5000000
+      },
+      "jobProperties" : {}
     }
   }
 }


### PR DESCRIPTION
This PR contains 2 changes:

1.   The R script used to execute the queries was broken because of the aggregation types 'min' and 'max'. As the [RDruid](https://github.com/druid-io/RDruid) still uses the old min max aggregators, I just used the underlaying function 
```R
druid.build.aggregation <- function(type, ...) {
  structure(list(type = type, ...), class="druid.aggregator")
}
```
to build the new ones.

2.   The  task descriptors lineitem.task.json and lineitem_small.task.json were out of date. I tried to translate them to the new format without modifying the old behavior.

I'm not very familiar with R and with druid itself so it's possible I did something wrong.